### PR TITLE
Add relative link to meeting minutes on welcome page

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -6,7 +6,7 @@ Welcome to the R Consortium R Submission Working Group!
 
 The R submission working group is a cross industry pharma working group focusing on improving practices of R-based clinical trial regulatory submissions.
 
-You can view previous meeting minutes with links to recorded sessions in the navigation bar above. 
+You can view previous meeting minutes with links to recorded sessions [here](minutes.qmd)
 
 # Our Mission
 


### PR DESCRIPTION
Fixes #122

## Changes

Add text and a relative link to `minutes.qmd` in `index.qmd`