### PR TITLE
Add new page for joining group

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -12,6 +12,8 @@ website:
       - href: index.qmd
         text: Home
       - minutes.qmd
+      - href: join.qmd
+        text: How to Join
       - text: "Pilots"
         menu: 
           - pilot_background.qmd

--- a/index.qmd
+++ b/index.qmd
@@ -14,3 +14,10 @@ You can view previous meeting minutes with links to recorded sessions [here](min
   - by showing open examples of using current submission portals
 - Easier R-based clinical trial regulatory submissions tomorrow
   - by collecting feedback and influencing future industry and agency decisions on system/process setup
+
+::: {.callout-tip}
+## Join the Team!
+
+Please visit the [How to Join](join.qmd) page for complete details on joining our working group.
+:::
+  

--- a/join.qmd
+++ b/join.qmd
@@ -1,0 +1,10 @@
+---
+title: How to Join
+---
+
+The Submissions Working Group welcomes all contributors who are passionate about bringing innovation to the clinical submission process! Here are the ways you can join the group's communication platforms and keep up-to-date with additional information:
+
+* Register for future Submissions Working Group meetings by visiting the [public calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/rcons?view=week). Our working group meetings typically occur on the first Friday of each month.
+* Send a note to our contact email: `operations[at]r-consortium.org`.
+* Join the Slock Group using the link [slack.r-consortium.org](https://slack.r-consortium.org) at the channel `#wg-submissions`.
+* Review the mailing list at [lists.r-consortium.org/g/Rconsortium-wg-submissions](https://lists.r-consortium.org/g/Rconsortium-wg-submissions)


### PR DESCRIPTION
This PR adds a new page to the site with details on how to join the working group.